### PR TITLE
[add] record=nilの時の挙動を追加

### DIFF
--- a/client.go
+++ b/client.go
@@ -247,6 +247,9 @@ func (a aeroSpikeClient) GetBalanceByAddress(address string) (float64, error) {
 	if err != nil {
 		return -1.0, err
 	}
+	if record == nil {
+		return 0.0, nil
+	}
 
 	bal, err := binMapToBalance(record)
 	if err != nil {


### PR DESCRIPTION
GetBalanceByAddress内部でまだ記録されてないアドレスを参照すると
```
record, err := a.client.Get(nil, key)
```
=> err = nil, record = nil
となり、recordが取得できないがエラーではない状態になります。
これによりbinMapToBalance(record)内部でpanicがおきます。

今回のPRはその場しのぎで最適解ではないですが、
問題提起 ＋ 一つの解決策 としてPRしておきます。:)